### PR TITLE
Improve Pokemon training pipeline

### DIFF
--- a/v2/requirements.txt
+++ b/v2/requirements.txt
@@ -59,6 +59,7 @@ scipy==1.14.1
 setuptools==75.1.0
 six==1.16.0
 stable_baselines3==2.3.2
+sb3-contrib==2.3.0
 stack-data==0.6.3
 sympy==1.13.1
 tensorboard==2.18.0


### PR DESCRIPTION
## Summary
- use RecurrentPPO with an LSTM policy
- tune PPO with four epochs and lower learning rate
- introduce intrinsic curiosity reward via RND
- enable level and opponent level rewards
- update dependencies to include sb3-contrib

## Testing
- `python -m py_compile v2/baseline_fast_v2.py v2/red_gym_env_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_6840352a8da88329a7969bf8aa4aeb88